### PR TITLE
Fix bugs for domain and version check

### DIFF
--- a/src/js/Helper/ServerRequirementCheck.js
+++ b/src/js/Helper/ServerRequirementCheck.js
@@ -78,8 +78,8 @@ export default class ServerRequirementCheck {
             parts = version.split('.');
 
         for(let i = 0; i < base.length; i++) {
-            if(!parts.hasOwnProperty(i) || parts[i] < base[i]) return false;
-            if(parts[i] > base[i]) return true;
+            if(!parts.hasOwnProperty(i) || Number(parts[i]) < Number(base[i])) return false;
+            if(Number(parts[i]) > Number(base[i])) return true;
         }
 
         return true;

--- a/src/js/Validation/Server.js
+++ b/src/js/Validation/Server.js
@@ -98,7 +98,7 @@ export default class Server {
             data.baseUrl += '/';
         }
 
-        let baseUrlRegex = /^https:\/\/[\w.\/]+$/;
+        let baseUrlRegex = /^https:\/\/[\w.\/\-]+$/;
         if(baseUrlRegex.test(errors.baseUrl)) {
             errors.baseUrl = LocalisationService.translate('ValidationNotAnUrl');
             return false;


### PR DESCRIPTION
@marius-wieschollek I've added fixes for two issues. I ran into a problem where I could use the Android apps by third parties with my domain `desk-apps.com` but not the browser extensions for Chrome and Firefox.

Then, during testing with Firefox and Chrome, I found that 2020.11.0 was not evaluating as being a greater version than 2020.3.

I also cannot find the latest version of the extension in either the Chrome or Firefox extension stores. Can we get this PR merged and the latest add-on released so I can use this awesome Nextcloud app with my browser workflows?

Thank you so much for your work on this!