### PR TITLE
Fix for valid domain names with keywords

### DIFF
--- a/src/vue/Sections/Settings.vue
+++ b/src/vue/Sections/Settings.vue
@@ -106,9 +106,9 @@
                 let a = document.createElement('a');
                 a.href = str;
                 return (a.host && a.host !== window.location.host) &&
-                       str.indexOf('index.php') === -1 &&
-                       str.indexOf('passwords') === -1 &&
-                       str.indexOf('apps') === -1;
+                       str.indexOf('/index.php') === -1 &&
+                       str.indexOf('/passwords') === -1 &&
+                       str.indexOf('/apps') === -1;
             }
         }
     };


### PR DESCRIPTION
Domain names like desk-apps.com were caught by the indexOf checks.