### PR TITLE
Introduce custom settings for password recommendations

### DIFF
--- a/src/js/Controller/Setting/Get.js
+++ b/src/js/Controller/Setting/Get.js
@@ -20,7 +20,8 @@ export default class Get extends AbstractController {
             'server.default',
             'theme.current',
             'theme.custom',
-            'debug.localisation.enabled'
+            'debug.localisation.enabled',
+            'search.recommendation.option'
         ];
     }
 

--- a/src/js/Controller/Setting/Get.js
+++ b/src/js/Controller/Setting/Get.js
@@ -21,7 +21,8 @@ export default class Get extends AbstractController {
             'theme.current',
             'theme.custom',
             'debug.localisation.enabled',
-            'search.recommendation.option'
+            'search.recommendation.option',
+            'search.recommendation.maxRows'
         ];
     }
 

--- a/src/js/Controller/Setting/Get.js
+++ b/src/js/Controller/Setting/Get.js
@@ -21,7 +21,7 @@ export default class Get extends AbstractController {
             'theme.current',
             'theme.custom',
             'debug.localisation.enabled',
-            'search.recommendation.option',
+            'search.recommendation.mode',
             'search.recommendation.maxRows'
         ];
     }

--- a/src/js/Controller/Setting/Reset.js
+++ b/src/js/Controller/Setting/Reset.js
@@ -18,7 +18,7 @@ export default class Reset extends AbstractController {
             'theme.current',
             'theme.custom',
             'debug.localisation.enabled',
-            'search.recommendation.option',
+            'search.recommendation.mode',
             'search.recommendation.maxRows'
         ];
     }

--- a/src/js/Controller/Setting/Reset.js
+++ b/src/js/Controller/Setting/Reset.js
@@ -18,7 +18,8 @@ export default class Reset extends AbstractController {
             'theme.current',
             'theme.custom',
             'debug.localisation.enabled',
-            'search.recommendation.option'
+            'search.recommendation.option',
+            'search.recommendation.maxRows'
         ];
     }
 

--- a/src/js/Controller/Setting/Reset.js
+++ b/src/js/Controller/Setting/Reset.js
@@ -17,7 +17,8 @@ export default class Reset extends AbstractController {
             'server.default',
             'theme.current',
             'theme.custom',
-            'debug.localisation.enabled'
+            'debug.localisation.enabled',
+            'search.recommendation.option'
         ];
     }
 

--- a/src/js/Controller/Setting/Set.js
+++ b/src/js/Controller/Setting/Set.js
@@ -36,8 +36,8 @@ export default class Set extends AbstractController {
                 await this._setDefaultServer(value);
             } else if(setting === 'theme.current') {
                 await this._setCurrentTheme(value);
-            } else if(setting === 'search.recommendation.option') {
-                await this._setSearchRecommendationOption(value);
+            } else if(setting === 'search.recommendation.mode') {
+                await this._setSearchRecommendationMode(value);
             } else if(setting === 'search.recommendation.maxRows') {
                 await this._setSearchRecommendationMaxRows(Number(value));
             } else if(this._booleanSettings.indexOf(setting) !== -1) {
@@ -91,8 +91,8 @@ export default class Set extends AbstractController {
      * @return {Promise<void>}
      * @private
      */
-    async _setSearchRecommendationOption(value) {
-        await SettingsService.set('search.recommendation.option', value);
+    async _setSearchRecommendationMode(value) {
+        await SettingsService.set('search.recommendation.mode', value);
     }
 
     /**

--- a/src/js/Controller/Setting/Set.js
+++ b/src/js/Controller/Setting/Set.js
@@ -36,6 +36,8 @@ export default class Set extends AbstractController {
                 await this._setDefaultServer(value);
             } else if(setting === 'theme.current') {
                 await this._setCurrentTheme(value);
+            } else if(setting === 'search.recommendation.option') {
+                await this._setSearchRecommendationOption(value);
             } else if(this._booleanSettings.indexOf(setting) !== -1) {
                 await this._setBoolean(setting, value);
             } else {
@@ -79,6 +81,16 @@ export default class Set extends AbstractController {
     async _setCurrentTheme(value) {
         await ThemeRepository.findById(value);
         await SettingsService.set('theme.current', value);
+    }
+
+    /**
+     *
+     * @param {String} value
+     * @return {Promise<void>}
+     * @private
+     */
+    async _setSearchRecommendationOption(value) {
+        await SettingsService.set('search.recommendation.option', value);
     }
 
     /**

--- a/src/js/Controller/Setting/Set.js
+++ b/src/js/Controller/Setting/Set.js
@@ -38,6 +38,8 @@ export default class Set extends AbstractController {
                 await this._setCurrentTheme(value);
             } else if(setting === 'search.recommendation.option') {
                 await this._setSearchRecommendationOption(value);
+            } else if(setting === 'search.recommendation.maxRows') {
+                await this._setSearchRecommendationMaxRows(Number(value));
             } else if(this._booleanSettings.indexOf(setting) !== -1) {
                 await this._setBoolean(setting, value);
             } else {
@@ -91,6 +93,16 @@ export default class Set extends AbstractController {
      */
     async _setSearchRecommendationOption(value) {
         await SettingsService.set('search.recommendation.option', value);
+    }
+
+    /**
+     *
+     * @param {Number} value
+     * @return {Promise<void>}
+     * @private
+     */
+    async _setSearchRecommendationMaxRows(value) {
+        await SettingsService.set('search.recommendation.maxRows', value);
     }
 
     /**

--- a/src/js/Manager/MiningManager.js
+++ b/src/js/Manager/MiningManager.js
@@ -3,6 +3,7 @@ import MiningItem from '@js/Models/Queue/MiningItem';
 import ServerManager from '@js/Manager/ServerManager';
 import ErrorManager from '@js/Manager/ErrorManager';
 import TabManager from '@js/Manager/TabManager';
+import RecommendationManager from '@js/Manager/RecommendationManager';
 import SearchQuery from '@js/Search/Query/SearchQuery';
 import SearchIndex from '@js/Search/Index/SearchIndex';
 import NotificationService from '@js/Services/NotificationService';
@@ -93,6 +94,8 @@ class MiningManager {
             if(basePassword !== null) {
                 task.setTaskField('id', basePassword.getId())
                     .setTaskField('label', basePassword.getLabel())
+                    .setTaskField('url', basePassword.getUrl())
+                    .setTaskField('hidden', basePassword.getHidden())
                     .setTaskNew(false);
             }
         }
@@ -220,7 +223,8 @@ class MiningManager {
         items = query
             .where(
                 query.field('password').equals(data.password.value),
-                query.field('username').equals(data.user.value)
+                query.field('username').equals(data.user.value),
+                RecommendationManager.getFilterQuery(query, Url(data.url))
             )
             .type('password')
             .hidden(tab.tab.incognito)
@@ -257,7 +261,7 @@ class MiningManager {
             items = query
                 .where(
                     query.field('username').equals(data.user.value),
-                    query.field('host').contains(url.host)
+                    RecommendationManager.getFilterQuery(query, Url(data.url))
                 )
                 .type('password')
                 .hidden(tab.tab.incognito)

--- a/src/js/Manager/RecommendationManager.js
+++ b/src/js/Manager/RecommendationManager.js
@@ -126,6 +126,7 @@ class RecommendationManager {
         }
         else {
             var domain = host.split(':')[0];
+            if(domain === domain.split('.')[0]) return domain;
             return domain.split('.').reverse()[1] + "." + domain.split('.').reverse()[0];
         }
     }

--- a/src/js/Manager/RecommendationManager.js
+++ b/src/js/Manager/RecommendationManager.js
@@ -3,6 +3,7 @@ import Url from 'url-parse';
 import TabManager from '@js/Manager/TabManager';
 import SearchIndex from '@js/Search/Index/SearchIndex';
 import EventQueue from '@js/Event/EventQueue';
+import SettingsService from '@js/Services/SettingsService';
 
 class RecommendationManager {
 
@@ -34,6 +35,17 @@ class RecommendationManager {
         TabManager.tabChanged.on(this._tabEvent);
         TabManager.urlChanged.on(this._tabEvent);
         SearchIndex.listen.on(this._searchEvent);
+        this.initRecommendationOptions();
+    }
+
+    initRecommendationOptions() {
+        this.options = { searchQuery: "Host", maxResults: 8 }
+        SettingsService.getValue('search.recommendation.option')
+        .then((value) => {
+            if(value) {
+                this.options.searchQuery = value;
+            }
+        });
     }
 
     /**
@@ -66,8 +78,18 @@ class RecommendationManager {
         let query = new SearchQuery('or');
         query
             .where(
-                query.field('host').equals(url.host),
-                query.field('url').contains(url.pathname.length > 1 ? url.host + url.pathname:url.host)
+                // search by domain
+                (this.options.searchQuery === "domain" ? query.field('host').contains(this.getSearchDomainFromHost(url.host)): 
+                    // search by hostname
+                    (this.options.searchQuery === "host" ? query.field('host').startsWith(url.host.split(':')[0]): 
+                        // search by hostname and port
+                        (this.options.searchQuery === "hostport" ? query.field('host').equals(url.host): 
+                            // search exact
+                            (this.options.searchQuery === "exact" ? query.field('url').equals(url.protocol + "//" + url.host + (url.pathname.length > 1 ? url.pathname: "")):
+                            "")
+                        )
+                    )
+                )
             )
             .type('password')
             .score(0.3)
@@ -81,6 +103,20 @@ class RecommendationManager {
         if(incognito) query.hidden(true);
 
         return query.execute();
+    }
+
+    /**
+     * @param {String} host
+     */
+    getSearchDomainFromHost(host) {
+        var regIPAdress = /((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$))/;
+        if (regIPAdress.test(host)) {
+            return host;
+        }
+        else {
+            var domain = host.split(':')[0];
+            return domain.split('.').reverse()[1] + "." + domain.split('.').reverse()[0];
+        }
     }
 
     /**

--- a/src/js/Manager/RecommendationManager.js
+++ b/src/js/Manager/RecommendationManager.js
@@ -39,11 +39,17 @@ class RecommendationManager {
     }
 
     initRecommendationOptions() {
-        this.options = { searchQuery: "Host", maxResults: 8 }
+        this.options = { searchQuery: "", maxResults: 8 }
         SettingsService.getValue('search.recommendation.option')
         .then((value) => {
             if(value) {
                 this.options.searchQuery = value;
+            }
+        });
+        SettingsService.getValue('search.recommendation.maxRows')
+        .then((value) => {
+            if(value) {
+                this.options.maxRows = Number(value);
             }
         });
     }
@@ -93,7 +99,7 @@ class RecommendationManager {
             )
             .type('password')
             .score(0.3)
-            .limit(8)
+            .limit(this.options.maxRows)
             .sortBy('favorite')
             .sortBy('uses')
             .sortBy('shared')

--- a/src/js/Manager/RecommendationManager.js
+++ b/src/js/Manager/RecommendationManager.js
@@ -39,7 +39,7 @@ class RecommendationManager {
     }
 
     initRecommendationOptions() {
-        this.options = { searchQuery: "", maxResults: 8 }
+        this.options = { searchQuery: "host", maxResults: 8 }
         SettingsService.getValue('search.recommendation.option')
         .then((value) => {
             if(value) {

--- a/src/js/Search/Query/Field/FieldFactory.js
+++ b/src/js/Search/Query/Field/FieldFactory.js
@@ -1,6 +1,7 @@
 import FieldEquals from '@js/Search/Query/Field/FieldEquals';
 import FieldContains from '@js/Search/Query/Field/FieldContains';
 import FieldMatches from '@js/Search/Query/Field/FieldMatches';
+import FieldStartsWith from '@js/Search/Query/Field/FieldStartsWith';
 import FieldIn from '@js/Search/Query/Field/FieldIn';
 import FieldNotEquals from '@js/Search/Query/Field/FieldNotEquals';
 import FieldNotIn from '@js/Search/Query/Field/FieldNotIn';
@@ -59,6 +60,21 @@ export default class FieldFactory {
         return new FieldMatches(name, value);
     }
 
+    /**
+     *
+     * @param {String} value
+     * @param {Number} [weight=null]
+     * @param {String} [name=null]
+     * @return {FieldContains}
+     */
+    startsWith(value, weight = null, name = null) {
+        if(!name) {
+            name = this._name;
+        }
+
+        return new FieldStartsWith(name, value, weight);
+    }
+    
     /**
      *
      * @param {String[]} value

--- a/src/js/Search/Query/Field/FieldStartsWith.js
+++ b/src/js/Search/Query/Field/FieldStartsWith.js
@@ -1,0 +1,42 @@
+import AbstractField from '@js/Search/Query/Field/AbstractField';
+
+export default class FieldStartsWith extends AbstractField {
+
+    /**
+     *
+     * @param {String} name
+     * @param {String} value
+     * @param {Number} weight
+     */
+    constructor(name, value, weight = 1) {
+        super(name, value);
+
+        if(weight <= 0) weight = 1;
+        this._weight = weight;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    evaluate(item) {
+        let values = this._getFieldValues(item);
+
+        if(!values) return {passed: false};
+
+        let search = this._value.toLowerCase(),
+            checks = 0,
+            matches = 0;
+
+        for(let value of values) {
+            checks++;
+            if(value.startsWith(search)) {
+                matches += value.split(search).length - 1;
+            }
+        }
+
+        if(this._weight !== 1) matches *= this._weight;
+        if(matches > 0) return {matches, checks, passed: true};
+
+        return {checks, passed: false};
+    }
+}

--- a/src/js/Settings/MasterSettingsProvider.js
+++ b/src/js/Settings/MasterSettingsProvider.js
@@ -77,26 +77,31 @@ class MasterSettingsProvider {
             'debug.localisation.enabled'  : [
                 'local.localisation.enabled'
             ],
-            'search.recommendation.option'               : [
+            'search.recommendation.maxRows': [
+                'sync.search.recommendation.maxRows',
+                'local.search.recommendation.maxRows'
+            ],
+            'search.recommendation.option': [
                 'sync.search.recommendation.option',
                 'local.search.recommendation.option'
             ],
         };
         this._defaults = {
-            'theme.custom'                : null,
-            'theme.current'               : 'light',
-            'server.default'              : null,
-            'paste.popup.close'           : true,
-            'paste.form.submit'           : true,
-            'paste.compromised.warning'   : true,
-            'paste.autofill'              : false,
-            'paste.basic-auth'   : false,
-            'popup.related.search'        : true,
-            'password.folder.private'     : null,
-            'notification.password.new'   : true,
-            'notification.password.update': true,
-            'debug.localisation.enabled'  : true,
-            'search.recommendation.option': 'host'
+            'theme.custom'                 : null,
+            'theme.current'                : 'light',
+            'server.default'               : null,
+            'paste.popup.close'            : true,
+            'paste.form.submit'            : true,
+            'paste.compromised.warning'    : true,
+            'paste.autofill'               : false,
+            'paste.basic-auth'             : false,
+            'popup.related.search'         : true,
+            'password.folder.private'      : null,
+            'notification.password.new'    : true,
+            'notification.password.update' : true,
+            'debug.localisation.enabled'   : true,
+            'search.recommendation.option' : 'host',
+            'search.recommendation.maxRows': 8
         };
     }
 

--- a/src/js/Settings/MasterSettingsProvider.js
+++ b/src/js/Settings/MasterSettingsProvider.js
@@ -76,7 +76,11 @@ class MasterSettingsProvider {
             ],
             'debug.localisation.enabled'  : [
                 'local.localisation.enabled'
-            ]
+            ],
+            'search.recommendation.option'               : [
+                'sync.search.recommendation.option',
+                'local.search.recommendation.option'
+            ],
         };
         this._defaults = {
             'theme.custom'                : null,
@@ -91,7 +95,8 @@ class MasterSettingsProvider {
             'password.folder.private'     : null,
             'notification.password.new'   : true,
             'notification.password.update': true,
-            'debug.localisation.enabled'  : true
+            'debug.localisation.enabled'  : true,
+            'search.recommendation.option': 'host'
         };
     }
 

--- a/src/js/Settings/MasterSettingsProvider.js
+++ b/src/js/Settings/MasterSettingsProvider.js
@@ -81,9 +81,9 @@ class MasterSettingsProvider {
                 'sync.search.recommendation.maxRows',
                 'local.search.recommendation.maxRows'
             ],
-            'search.recommendation.option': [
-                'sync.search.recommendation.option',
-                'local.search.recommendation.option'
+            'search.recommendation.mode': [
+                'sync.search.recommendation.mode',
+                'local.search.recommendation.mode'
             ],
         };
         this._defaults = {
@@ -100,7 +100,7 @@ class MasterSettingsProvider {
             'notification.password.new'    : true,
             'notification.password.update' : true,
             'debug.localisation.enabled'   : true,
-            'search.recommendation.option' : 'host',
+            'search.recommendation.mode'   : 'host',
             'search.recommendation.maxRows': 8
         };
     }

--- a/src/platform/generic/_locales/de/messages.json
+++ b/src/platform/generic/_locales/de/messages.json
@@ -1176,5 +1176,25 @@
     "DebugNoErrors"                 : {
         "message"    : "Keine Fehlerberichte vorhanden",
         "description": "Message shown when no error reports exist instead of the error logs in the error logs section in the extension settings in the debug tab"
+    },
+    "SettingsSearchRecommendationOption"     : {
+        "message"    : "Suche Passwort empfehlungen auf Basis von dieser Option.",
+        "description": "Label of the setting in the extension settings to define how password recommendations are searched."
+    },    
+    "LabelSearchRecommendationDomain"                 : {
+        "message"    : "Domain",
+        "description": "Find password recommendations by domain. So on page mail.example.com you will see all passwords for the domain and sumdomains of example.com."
+    },    
+    "LabelSearchRecommendationHost"                 : {
+        "message"    : "Host",
+        "description": "Find password recommendations by host. So on page mail.example.com you will see all passwords for the sumdomain mail e.g. (mail.example.com or mail.example.com:8443)."
+    },    
+    "LabelSearchRecommendationHostPort"                 : {
+        "message"    : "Host + Port",
+        "description": "Find password recommendations for the specific server and port."
+    },    
+    "LabelSearchRecommendationExact"                 : {
+        "message"    : "Exakte URL",
+        "description": "Find only passwords where th url matches exact to the current browser url."
     }
 }

--- a/src/platform/generic/_locales/de/messages.json
+++ b/src/platform/generic/_locales/de/messages.json
@@ -1208,85 +1208,15 @@
     "SettingsSearchRecommendationMaxRows"     : {
         "message"    : "Maximale Anzahl an Ergebnissen für die Password Empfehlung.",
         "description": "Label of the setting in the extension settings to define the maximum number of results for the password recommendation."
-    },    
-    "LabelSearchRecommendationRows1"                 : {
-        "message"    : "1",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows2"                 : {
-        "message"    : "2",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows3"                 : {
-        "message"    : "3",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows4"                 : {
-        "message"    : "4",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows5"                 : {
-        "message"    : "5",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows6"                 : {
-        "message"    : "6",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows7"                 : {
-        "message"    : "7",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows8"                 : {
-        "message"    : "8",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows9"                 : {
-        "message"    : "9",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows10"                 : {
-        "message"    : "10",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows11"                 : {
-        "message"    : "11",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows12"                 : {
-        "message"    : "12",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows13"                 : {
-        "message"    : "13",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows14"                 : {
-        "message"    : "14",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows15"                 : {
-        "message"    : "15",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows16"                 : {
-        "message"    : "16",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows17"                 : {
-        "message"    : "17",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows18"                 : {
-        "message"    : "18",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows19"                 : {
-        "message"    : "19",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows20"                 : {
-        "message"    : "20",
-        "description": "Number of results that should be displayed for password recommendations."
+    },
+    "SearchRecommendationMaxRowsNumber"    : {
+        "message"     : "$ROW$",
+        "description" : "Number of results that should be displayed for password recommendations.",
+        "placeholders": {
+            "row": {
+                "content": "$1",
+                "example": "One of 1, 5, 10, 15 or 20"
+            }
+        }
     }
 }

--- a/src/platform/generic/_locales/de/messages.json
+++ b/src/platform/generic/_locales/de/messages.json
@@ -1177,6 +1177,14 @@
         "message"    : "Keine Fehlerberichte vorhanden",
         "description": "Message shown when no error reports exist instead of the error logs in the error logs section in the extension settings in the debug tab"
     },
+    "RecommendationSettings"     : {
+        "message"    : "Password empfehlungen",
+        "description": "Label of the section password recommendations in the extension settings."
+    },
+    "RecommendationSettingsHelp"     : {
+        "message"    : "Beim ändern doeser Einstellungen muss die Erweiterung neu gestartet werden. Entweder durch deaktivieren und aktivieren der Erweiterung oder mit einem Browser neustart.",
+        "description": "Label of the help text for section password recommendations in the extension settings."
+    },
     "SettingsSearchRecommendationOption"     : {
         "message"    : "Suche Passwort empfehlungen auf Basis von dieser Option.",
         "description": "Label of the setting in the extension settings to define how password recommendations are searched."
@@ -1196,5 +1204,89 @@
     "LabelSearchRecommendationExact"                 : {
         "message"    : "Exakte URL",
         "description": "Find only passwords where th url matches exact to the current browser url."
+    },
+    "SettingsSearchRecommendationMaxRows"     : {
+        "message"    : "Maximale Anzahl an Ergebnissen für die Password Empfehlung.",
+        "description": "Label of the setting in the extension settings to define the maximum number of results for the password recommendation."
+    },    
+    "LabelSearchRecommendationRows1"                 : {
+        "message"    : "1",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows2"                 : {
+        "message"    : "2",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows3"                 : {
+        "message"    : "3",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows4"                 : {
+        "message"    : "4",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows5"                 : {
+        "message"    : "5",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows6"                 : {
+        "message"    : "6",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows7"                 : {
+        "message"    : "7",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows8"                 : {
+        "message"    : "8",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows9"                 : {
+        "message"    : "9",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows10"                 : {
+        "message"    : "10",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows11"                 : {
+        "message"    : "11",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows12"                 : {
+        "message"    : "12",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows13"                 : {
+        "message"    : "13",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows14"                 : {
+        "message"    : "14",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows15"                 : {
+        "message"    : "15",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows16"                 : {
+        "message"    : "16",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows17"                 : {
+        "message"    : "17",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows18"                 : {
+        "message"    : "18",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows19"                 : {
+        "message"    : "19",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows20"                 : {
+        "message"    : "20",
+        "description": "Number of results that should be displayed for password recommendations."
     }
 }

--- a/src/platform/generic/_locales/de/messages.json
+++ b/src/platform/generic/_locales/de/messages.json
@@ -1178,15 +1178,15 @@
         "description": "Message shown when no error reports exist instead of the error logs in the error logs section in the extension settings in the debug tab"
     },
     "RecommendationSettings"     : {
-        "message"    : "Password empfehlungen",
+        "message"    : "Passwort Empfehlung",
         "description": "Label of the section password recommendations in the extension settings."
     },
     "RecommendationSettingsHelp"     : {
-        "message"    : "Beim ändern doeser Einstellungen muss die Erweiterung neu gestartet werden. Entweder durch deaktivieren und aktivieren der Erweiterung oder mit einem Browser neustart.",
+        "message"    : "Beim Ändern dieser Einstellungen muss die Erweiterung neu gestartet werden. Entweder durch deaktivieren und aktivieren der Erweiterung oder mit einem Browser Neustart.",
         "description": "Label of the help text for section password recommendations in the extension settings."
     },
     "SettingsSearchRecommendationOption"     : {
-        "message"    : "Suche Passwort empfehlungen auf Basis von dieser Option.",
+        "message"    : "Suche Passwort Empfehlung auf Basis von dieser Option.",
         "description": "Label of the setting in the extension settings to define how password recommendations are searched."
     },    
     "LabelSearchRecommendationDomain"                 : {
@@ -1206,7 +1206,7 @@
         "description": "Find only passwords where th url matches exact to the current browser url."
     },
     "SettingsSearchRecommendationMaxRows"     : {
-        "message"    : "Maximale Anzahl an Ergebnissen für die Password Empfehlung.",
+        "message"    : "Maximale Anzahl an Ergebnissen für die Passwort Empfehlung.",
         "description": "Label of the setting in the extension settings to define the maximum number of results for the password recommendation."
     },
     "SearchRecommendationMaxRowsNumber"    : {

--- a/src/platform/generic/_locales/en/messages.json
+++ b/src/platform/generic/_locales/en/messages.json
@@ -1191,6 +1191,14 @@
         "message"    : "No errors in log",
         "description": "Message shown when no error reports exist instead of the error logs in the error logs section in the extension settings in the debug tab"
     },
+    "RecommendationSettings"     : {
+        "message"    : "Password recommendations",
+        "description": "Label of the section password recommendations in the extension settings."
+    },
+    "RecommendationSettingsHelp"     : {
+        "message"    : "If you change the settings below you will need to restart the extension. This can be done by disabling/enabling the extension or with a browser restart.",
+        "description": "Label of the help text for section password recommendations in the extension settings."
+    },
     "SettingsSearchRecommendationOption"     : {
         "message"    : "Search passwords based on the following option.",
         "description": "Label of the setting in the extension settings to define how password recommendations are searched."
@@ -1210,5 +1218,89 @@
     "LabelSearchRecommendationExact"                 : {
         "message"    : "Exact url",
         "description": "Find only passwords where th url matches exact to the current browser url."
+    },
+    "SettingsSearchRecommendationMaxRows"     : {
+        "message"    : "Maximum number of results for the password recommendation.",
+        "description": "Label of the setting in the extension settings to define the maximum number of results for the password recommendation."
+    },    
+    "LabelSearchRecommendationRows1"                 : {
+        "message"    : "1",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows2"                 : {
+        "message"    : "2",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows3"                 : {
+        "message"    : "3",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows4"                 : {
+        "message"    : "4",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows5"                 : {
+        "message"    : "5",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows6"                 : {
+        "message"    : "6",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows7"                 : {
+        "message"    : "7",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows8"                 : {
+        "message"    : "8",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows9"                 : {
+        "message"    : "9",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows10"                 : {
+        "message"    : "10",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows11"                 : {
+        "message"    : "11",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows12"                 : {
+        "message"    : "12",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows13"                 : {
+        "message"    : "13",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows14"                 : {
+        "message"    : "14",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows15"                 : {
+        "message"    : "15",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows16"                 : {
+        "message"    : "16",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows17"                 : {
+        "message"    : "17",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows18"                 : {
+        "message"    : "18",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows19"                 : {
+        "message"    : "19",
+        "description": "Number of results that should be displayed for password recommendations."
+    },    
+    "LabelSearchRecommendationRows20"                 : {
+        "message"    : "20",
+        "description": "Number of results that should be displayed for password recommendations."
     }
 }

--- a/src/platform/generic/_locales/en/messages.json
+++ b/src/platform/generic/_locales/en/messages.json
@@ -1222,85 +1222,15 @@
     "SettingsSearchRecommendationMaxRows"     : {
         "message"    : "Maximum number of results for the password recommendation.",
         "description": "Label of the setting in the extension settings to define the maximum number of results for the password recommendation."
-    },    
-    "LabelSearchRecommendationRows1"                 : {
-        "message"    : "1",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows2"                 : {
-        "message"    : "2",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows3"                 : {
-        "message"    : "3",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows4"                 : {
-        "message"    : "4",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows5"                 : {
-        "message"    : "5",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows6"                 : {
-        "message"    : "6",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows7"                 : {
-        "message"    : "7",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows8"                 : {
-        "message"    : "8",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows9"                 : {
-        "message"    : "9",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows10"                 : {
-        "message"    : "10",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows11"                 : {
-        "message"    : "11",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows12"                 : {
-        "message"    : "12",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows13"                 : {
-        "message"    : "13",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows14"                 : {
-        "message"    : "14",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows15"                 : {
-        "message"    : "15",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows16"                 : {
-        "message"    : "16",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows17"                 : {
-        "message"    : "17",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows18"                 : {
-        "message"    : "18",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows19"                 : {
-        "message"    : "19",
-        "description": "Number of results that should be displayed for password recommendations."
-    },    
-    "LabelSearchRecommendationRows20"                 : {
-        "message"    : "20",
-        "description": "Number of results that should be displayed for password recommendations."
+    },
+    "SearchRecommendationMaxRowsNumber"    : {
+        "message"     : "$ROW$",
+        "description" : "Number of results that should be displayed for password recommendations.",
+        "placeholders": {
+            "row": {
+                "content": "$1",
+                "example": "One of 1, 5, 10, 15 or 20"
+            }
+        }
     }
 }

--- a/src/platform/generic/_locales/en/messages.json
+++ b/src/platform/generic/_locales/en/messages.json
@@ -1190,5 +1190,25 @@
     "DebugNoErrors"                 : {
         "message"    : "No errors in log",
         "description": "Message shown when no error reports exist instead of the error logs in the error logs section in the extension settings in the debug tab"
+    },
+    "SettingsSearchRecommendationOption"     : {
+        "message"    : "Search passwords based on the following option.",
+        "description": "Label of the setting in the extension settings to define how password recommendations are searched."
+    },    
+    "LabelSearchRecommendationDomain"                 : {
+        "message"    : "Domain",
+        "description": "Find password recommendations by domain. So on page mail.example.com you will see all passwords for the domain and sumdomains of example.com."
+    },    
+    "LabelSearchRecommendationHost"                 : {
+        "message"    : "Host",
+        "description": "Find password recommendations by host. So on page mail.example.com you will see all passwords for the sumdomain mail e.g. (mail.example.com or mail.example.com:8443)."
+    },    
+    "LabelSearchRecommendationHostPort"                 : {
+        "message"    : "Host + Port",
+        "description": "Find password recommendations for the specific server and port."
+    },    
+    "LabelSearchRecommendationExact"                 : {
+        "message"    : "Exact url",
+        "description": "Find only passwords where th url matches exact to the current browser url."
     }
 }

--- a/src/vue/Components/Options/Settings.vue
+++ b/src/vue/Components/Options/Settings.vue
@@ -39,9 +39,16 @@
             <slider-field id="popup-related-search" v-model="relatedSearch"/>
             <translate tag="label" for="popup-related-search" say="SettingsPopupRelatedSearch"/>
         </div>
-        <div class="setting dropdown">
+
+        <translate tag="h3" say="RecommendationSettings"/>
+        <translate tag="p" say="RecommendationSettingsHelp"/>
+        <div class="setting">
             <translate tag="label" for="search-recommendation-option" say="SettingsSearchRecommendationOption"/>
-            <select-field id="search-recommendation-option" :options="recommendationOptions" v-model="searchOption"/>
+            <select-field id="search-recommendation-option" :options="recommendationOptions" v-model="recSearchOption"/>
+        </div>
+        <div class="setting">
+            <translate tag="label" for="search-recommendation-maxRows" say="SettingsSearchRecommendationMaxRows"/>
+            <select-field id="search-recommendation-maxRows" :options="recommendationMaxRows" v-model="recSearchRows"/>
         </div>
     </div>
 </template>
@@ -59,15 +66,16 @@
         components: {HelpText, SliderField, SelectField, Translate},
         data() {
             return {
-                autoclose     : false,
-                autosubmit    : false,
-                autofill      : false,
-                basicAuth     : false,
-                compromised   : false,
-                notifyPwNew   : false,
-                relatedSearch : false,
-                notifyPwUpdate: false,
-                searchOption  : 'host'
+                autoclose        : false,
+                autosubmit       : false,
+                autofill         : false,
+                basicAuth        : false,
+                compromised      : false,
+                notifyPwNew      : false,
+                relatedSearch    : false,
+                notifyPwUpdate   : false,
+                recSearchOption  : 'host',
+                recSearchRows    : 8
             };
         },
 
@@ -95,6 +103,14 @@
                         label: 'LabelSearchRecommendationExact'
                     }
                 ];
+            },
+            recommendationMaxRows() {
+                var i = 1;
+                var result = [];
+                for(i =1; i <= 20; i++) {
+                    result.push({id: i, label: "LabelSearchRecommendationRows" + i.toString()})
+                }
+                return result;               
             }
         },
 
@@ -108,7 +124,8 @@
                 this.getSetting('popup.related.search', 'relatedSearch');
                 this.getSetting('notification.password.new', 'notifyPwNew');
                 this.getSetting('notification.password.update', 'notifyPwUpdate');
-                this.getSetting('search.recommendation.option', 'searchOption');
+                this.getSetting('search.recommendation.option', 'recSearchOption');
+                this.getSetting('search.recommendation.maxRows', 'recSearchRows');
             },
             async getSetting(name, variable) {
                 try {
@@ -169,12 +186,14 @@
                     this.setSetting('notification.password.update', value);
                 }
             },
-            searchOption(value, oldValue) {
-                console.log("value   : " + value);
-                console.log("oldvalue: " + oldValue);
+            recSearchOption(value, oldValue) {
                 if(oldValue !== null && value !== oldValue) {
-                    console.log("yeah");
                     this.setSetting('search.recommendation.option', value);
+                }
+            },
+            recSearchRows(value, oldValue) {
+                if(oldValue !== null && value !== oldValue) {
+                    this.setSetting('search.recommendation.maxRows', value);
                 }
             }
         }
@@ -185,6 +204,9 @@
 .debug-settings,
 .settings-general {
     h3 {
+        margin : 1.5rem 1rem .5rem;
+    }
+    p {
         margin : 1.5rem 1rem .5rem;
     }
 
@@ -206,10 +228,6 @@
 
         .settings-help-text {
             margin-right : -.5rem;
-        }
-
-        .dropdown {
-            align-items: flex-start
         }
     }
 }

--- a/src/vue/Components/Options/Settings.vue
+++ b/src/vue/Components/Options/Settings.vue
@@ -44,7 +44,7 @@
         <translate tag="p" say="RecommendationSettingsHelp"/>
         <div class="setting">
             <translate tag="label" for="search-recommendation-option" say="SettingsSearchRecommendationOption"/>
-            <select-field id="search-recommendation-option" :options="recommendationOptions" v-model="recSearchOption"/>
+            <select-field id="search-recommendation-option" :options="recommendationOptions" v-model="recSearchMode"/>
         </div>
         <div class="setting">
             <translate tag="label" for="search-recommendation-maxRows" say="SettingsSearchRecommendationMaxRows"/>
@@ -74,7 +74,7 @@
                 notifyPwNew      : false,
                 relatedSearch    : false,
                 notifyPwUpdate   : false,
-                recSearchOption  : 'host',
+                recSearchMode    : 'host',
                 recSearchRows    : 8
             };
         },
@@ -108,7 +108,7 @@
                 var i = 1;
                 var result = [];
                 for(i =1; i <= 20; i++) {
-                    result.push({id: i, label: "LabelSearchRecommendationRows" + i.toString()})
+                    result.push({id: i, label: ['SearchRecommendationMaxRowsNumber', i]});
                 }
                 return result;               
             }
@@ -124,7 +124,7 @@
                 this.getSetting('popup.related.search', 'relatedSearch');
                 this.getSetting('notification.password.new', 'notifyPwNew');
                 this.getSetting('notification.password.update', 'notifyPwUpdate');
-                this.getSetting('search.recommendation.option', 'recSearchOption');
+                this.getSetting('search.recommendation.mode', 'recSearchMode');
                 this.getSetting('search.recommendation.maxRows', 'recSearchRows');
             },
             async getSetting(name, variable) {
@@ -186,9 +186,9 @@
                     this.setSetting('notification.password.update', value);
                 }
             },
-            recSearchOption(value, oldValue) {
+            recSearchMode(value, oldValue) {
                 if(oldValue !== null && value !== oldValue) {
-                    this.setSetting('search.recommendation.option', value);
+                    this.setSetting('search.recommendation.mode', value);
                 }
             },
             recSearchRows(value, oldValue) {

--- a/src/vue/Components/Options/Settings.vue
+++ b/src/vue/Components/Options/Settings.vue
@@ -39,6 +39,10 @@
             <slider-field id="popup-related-search" v-model="relatedSearch"/>
             <translate tag="label" for="popup-related-search" say="SettingsPopupRelatedSearch"/>
         </div>
+        <div class="setting dropdown">
+            <translate tag="label" for="search-recommendation-option" say="SettingsSearchRecommendationOption"/>
+            <select-field id="search-recommendation-option" :options="recommendationOptions" v-model="searchOption"/>
+        </div>
     </div>
 </template>
 
@@ -48,10 +52,11 @@
     import SettingsService from '@js/Services/SettingsService';
     import ToastService from '@js/Services/ToastService';
     import SliderField from "@vue/Components/Form/SliderField";
+    import SelectField from "@vue/Components/Form/SelectField";
     import HelpText from "@vue/Components/Options/Setting/HelpText";
 
     export default {
-        components: {HelpText, SliderField, Translate},
+        components: {HelpText, SliderField, SelectField, Translate},
         data() {
             return {
                 autoclose     : false,
@@ -61,12 +66,36 @@
                 compromised   : false,
                 notifyPwNew   : false,
                 relatedSearch : false,
-                notifyPwUpdate: false
+                notifyPwUpdate: false,
+                searchOption  : 'host'
             };
         },
 
         created() {
             this.loadData();
+        },
+
+        computed: {
+            recommendationOptions() {
+                return [
+                    {
+                        id   : 'domain',
+                        label: 'LabelSearchRecommendationDomain'
+                    },
+                    {
+                        id   : 'host',
+                        label: 'LabelSearchRecommendationHost'
+                    },
+                    {
+                        id   : 'hostport',
+                        label: 'LabelSearchRecommendationHostPort'
+                    },
+                    {
+                        id   : 'exact',
+                        label: 'LabelSearchRecommendationExact'
+                    }
+                ];
+            }
         },
 
         methods: {
@@ -79,6 +108,7 @@
                 this.getSetting('popup.related.search', 'relatedSearch');
                 this.getSetting('notification.password.new', 'notifyPwNew');
                 this.getSetting('notification.password.update', 'notifyPwUpdate');
+                this.getSetting('search.recommendation.option', 'searchOption');
             },
             async getSetting(name, variable) {
                 try {
@@ -138,6 +168,14 @@
                 if(oldValue !== null && value !== oldValue) {
                     this.setSetting('notification.password.update', value);
                 }
+            },
+            searchOption(value, oldValue) {
+                console.log("value   : " + value);
+                console.log("oldvalue: " + oldValue);
+                if(oldValue !== null && value !== oldValue) {
+                    console.log("yeah");
+                    this.setSetting('search.recommendation.option', value);
+                }
             }
         }
     };
@@ -168,6 +206,10 @@
 
         .settings-help-text {
             margin-right : -.5rem;
+        }
+
+        .dropdown {
+            align-items: flex-start
         }
     }
 }


### PR DESCRIPTION
I would like to move from lastpass to nextcloud passwords for serval reasons. I find the implementation really nice so thanks to all contributors here!

For me there is one importand setting missing and it seams that I'm not alone. If you have an ldap server you will probably have multiple web pages with the same user. With the currend implementation of password recommendations this will get a problem. For this reason I implemented a possibility to change the way how password recommendations are searched.

In the advanced extension settings a new section "Password recommendations" was added. You can define the following settings there.

1. **Search passwords based on the following option**. This defines the way password recommendations are searched. The setting has 4 options (default is "host"). Below is some example to explain how they work when you are on the web page "www.example.com:8443/login":
 
   - **Domain** - This will search for all passwords on the same domain. 
       - example.com                             -> visible
       - www.example.com                    -> visible
       - www.example.com:8443            -> visible
       - www.example.com:8443/login  -> visible
     
   - **Host** - This will search for all passwords on the same host. 
       - example.com                             -> not visible
       - www.example.com                    -> visible
       - www.example.com:8443            -> visible
       - www.example.com:8443/login  -> visible
       
   - **Host + Port** - This will search for all passwords on the same host and port. 
       - example.com                             -> not visible
       - www.example.com                    -> not visible
       - www.example.com:8443            -> visible
       - www.example.com:8443/login  -> visible
       
   - **Exact url** - This will search for all passwords where the url is equal to the current web page. 
       - example.com                             -> not visible
       - www.example.com                    -> not visible
       - www.example.com:8443            -> not visible
       - www.example.com:8443/login  -> visible

2. **Maximum number of results for the password recommendation**. This defines how many results are shown. I found this #141 open issue. Due to the fact that I was customizing this class for the first setting it was an easy change to add also the second option. You can define a value between 1 and 20 (default is set to 8).

![image](https://user-images.githubusercontent.com/52607335/108595243-15e06380-737f-11eb-97a2-7dcd19144bee.png)

The following issues can be fixed with this change:
Fixes #141
Fixes #87
Fixes #14

This change also replaces #147 because it allows configuring this setting in the extension settings.