### PR TITLE
fix autofill not working on page load

### DIFF
--- a/src/js/App/Client.js
+++ b/src/js/App/Client.js
@@ -3,6 +3,7 @@ import ErrorManager from '@js/Manager/ErrorManager';
 import MessageService from '@js/Services/MessageService';
 import ConverterManager from '@js/Manager/ConverterManager';
 import ClientControllerManager from '@js/Manager/ClientControllerManager';
+import AutofillManager from '@js/Manager/AutofillManager';
 import DomMiner from '@js/Miner/DomMiner';
 
 class Client {
@@ -17,6 +18,7 @@ class Client {
             ClientControllerManager.init();
             let miner = new DomMiner();
             miner.init();
+            AutofillManager.initClient();
         } catch(e) {
             ErrorManager.logError(e);
         }

--- a/src/js/Manager/AutofillManager.js
+++ b/src/js/Manager/AutofillManager.js
@@ -8,18 +8,54 @@ export default new class AutofillManager {
 
     constructor() {
         this._recommendationListener = (recommendations) => {
-            this._sendAutofillPassword(recommendations);
+            this.recommendations = recommendations;
+            this.currentURL =TabManager.getAll()[TabManager.currentTabId].url
         };
-        this._sendPasswordToMessageService = (recommendations) => {
-            this._sendPwdToMessageService(recommendations);
-        };
+        this.recommendations = [];  
+        this.currentURL = null;      
     }
 
     /**
      *
      */
-    init() {
+    async init() {
         RecommendationManager.listen.on(this._recommendationListener);
+        MessageService.listen(
+            'autofill.page.ready',
+            (message, reply) => {
+                if(message.url = this.currentURL) {
+                    this._sendAutofillPassword(this.recommendations);
+                }
+            }
+        );
+    }
+
+    /**
+     *
+     */
+    initClient() {
+        if (document.readyState === "complete" 
+            || document.readyState === "loaded" 
+            || document.readyState === "interactive") {
+            this._sendBrowserPageReadyMessage()
+       } else {
+        window.addEventListener("domcontentloaded", this._sendBrowserPageReadyMessage());
+       }
+    }
+
+    /**
+     *
+     */
+    _sendBrowserPageReadyMessage() {
+        MessageService.send(
+            {
+                type    : 'autofill.page.ready',
+                payload : {
+                    url: window.location.href
+                },
+                receiver: 'background'
+            }
+        );
     }
 
     /**
@@ -30,16 +66,15 @@ export default new class AutofillManager {
     async _sendAutofillPassword(recommendations) {
         if(recommendations.length === 0 || await SettingsService.getValue('paste.autofill') === false) return;
         let password = recommendations[0];
-        var self = this;
 
-        setTimeout(function () {
+        setTimeout(() => {
             let ids = TabManager.get('autofill.ids', []);
             if(ids.indexOf(password.getId()) === -1) {
                 ids.push(password.getId());
                 TabManager.set('autofill.ids', ids);
             }
-            self._sendPasswordToMessageService(password);
-        }, 2500);
+            this._sendPwdToMessageService(password);
+        }, 500);
     }
 
     /**

--- a/src/js/Manager/AutofillManager.js
+++ b/src/js/Manager/AutofillManager.js
@@ -10,6 +10,9 @@ export default new class AutofillManager {
         this._recommendationListener = (recommendations) => {
             this._sendAutofillPassword(recommendations);
         };
+        this._sendPasswordToMessageService = (recommendations) => {
+            this._sendPwdToMessageService(recommendations);
+        };
     }
 
     /**
@@ -27,13 +30,24 @@ export default new class AutofillManager {
     async _sendAutofillPassword(recommendations) {
         if(recommendations.length === 0 || await SettingsService.getValue('paste.autofill') === false) return;
         let password = recommendations[0];
+        var self = this;
 
-        let ids = TabManager.get('autofill.ids', []);
-        if(ids.indexOf(password.getId()) === -1) {
-            ids.push(password.getId());
-            TabManager.set('autofill.ids', ids);
-        }
+        setTimeout(function () {
+            let ids = TabManager.get('autofill.ids', []);
+            if(ids.indexOf(password.getId()) === -1) {
+                ids.push(password.getId());
+                TabManager.set('autofill.ids', ids);
+            }
+            self._sendPasswordToMessageService(password);
+        }, 2500);
+    }
 
+    /**
+     *
+     * @param {Password[]} recommendations
+     * @private
+     */
+    _sendPwdToMessageService(password) {
         MessageService.send(
             {
                 type    : 'autofill.password',

--- a/src/js/Services/MessageService.js
+++ b/src/js/Services/MessageService.js
@@ -292,7 +292,7 @@ class MessageService {
      */
     _checkClientRestrictions(message) {
         return message.getSender() !== 'client' ||
-               (message.getType() !== 'password.mine' && message.getType() !== 'queue.items' && message.getType() !== 'debug.form.fields') ||
+               (message.getType() !== 'password.mine' && message.getType() !== 'queue.items' && message.getType() !== 'debug.form.fields' && message.getType() !== 'autofill.page.ready') ||
                (message.getType() === 'queue.items' && message.getPayload().name !== 'error');
     }
 


### PR DESCRIPTION
I noticed that the autofill feature is not working on page load. Only on tab change event.

After some tests I figured out that the event fires before the login form is loaded, so it can not find the autofill controls of the webpage.

I added some delay for the autofill feature to solve the bug. I choosed 2,5 seconds for the delay. With this delay autofill  worked on most of my test pages. Only on pages where the connection was really slow autofill still failed. 