### PR TITLE
fix password 3 times detected bug

### DIFF
--- a/src/js/Miner/DomMiner.js
+++ b/src/js/Miner/DomMiner.js
@@ -3,6 +3,13 @@ import MessageService from '@js/Services/MessageService';
 
 export default class DomMiner {
 
+    /**
+     *
+     */
+    constructor() {
+        this._knownForms = [];
+    }
+
     init() {
         window.addEventListener(
             'beforeunload',
@@ -35,6 +42,27 @@ export default class DomMiner {
         for(let form of forms) {
             this._checkFormForPassword(form);
         }
+        this._knownForms = [];
+    }
+
+    _checkForDuplication(form) {
+        var exists = false;
+        this._knownForms.forEach(element => {
+            if((element.pass == form.pass.value) &&
+                (element.user == form.user.value) &&
+                (element.url == this._getUrl())) {
+                exists = true;
+            }            
+        });      
+        if(exists === false) {
+            this._knownForms.push(
+            {
+                pass: form.pass.value, 
+                user: form.user.value,
+                url: this._getUrl()
+            });  
+        }
+        return exists;
     }
 
     /**
@@ -43,6 +71,7 @@ export default class DomMiner {
      * @private
      */
     _checkFormForPassword(form) {
+        if(this._checkForDuplication(form)) return;
         if(form.pass.value.length !== 0 && form.pass.value.trim().length !== 0) {
             let info = {
                 url     : this._getUrl(),


### PR DESCRIPTION
I noticed that the detected password is send 3 times on some pages because all 3 events of the miner are running. On others only one or 2 passwords are detected depending how many events of the miner are triggered from the webpage.

The message queue is searching for duplicates, but the 3 messages come nearly to the same time and this makes problems. 

For this reason I added some array to the miner client and fill it with known passwords/user/url combination. Before sending the credentials to the message service it checks if they are already known. The array gets empty again on page unload so we can ensure that the next window can not cache them.

This pull request fixes the following issues:
Fixes #146 