### PR TITLE
Introduce "Show username next to title" option

### DIFF
--- a/src/js/App/Popup.js
+++ b/src/js/App/Popup.js
@@ -10,6 +10,7 @@ import ThemeService from '@js/Services/ThemeService';
 import SettingsService from '@js/Services/SettingsService';
 import ClientSettingsProvider from '@js/Settings/ClientSettingsProvider';
 import LocalisationService from "@js/Services/LocalisationService";
+import PasswordSettingsManager from '@js/Manager/PasswordSettingsManager';
 
 class Popup {
 
@@ -44,6 +45,7 @@ class Popup {
             await MessageService.init(true, 'background');
             ConverterManager.init();
             SettingsService.init(ClientSettingsProvider);
+            await PasswordSettingsManager.init();
             this._authClient = new AuthorisationClient();
 
             await ThemeService.apply();

--- a/src/js/Controller/Setting/Get.js
+++ b/src/js/Controller/Setting/Get.js
@@ -24,7 +24,8 @@ export default class Get extends AbstractController {
             'clipboard.clear.delay',
             'clipboard.clear.passwords',
             'search.recommendation.mode',
-            'search.recommendation.maxRows'
+            'search.recommendation.maxRows',
+            'password.list.show.user'
         ];
     }
 

--- a/src/js/Controller/Setting/Reset.js
+++ b/src/js/Controller/Setting/Reset.js
@@ -21,7 +21,8 @@ export default class Reset extends AbstractController {
             'search.recommendation.mode',
             'search.recommendation.maxRows',
             'clipboard.clear.passwords',
-            'clipboard.clear.delay'
+            'clipboard.clear.delay',
+            'password.list.show.user'
         ];
     }
 

--- a/src/js/Controller/Setting/Set.js
+++ b/src/js/Controller/Setting/Set.js
@@ -17,7 +17,8 @@ export default class Set extends AbstractController {
             'notification.password.new',
             'notification.password.update',
             'debug.localisation.enabled',
-            'clipboard.clear.passwords'
+            'clipboard.clear.passwords',
+            'password.list.show.user'
         ];
     }
 

--- a/src/js/Manager/PasswordSettingsManager.js
+++ b/src/js/Manager/PasswordSettingsManager.js
@@ -1,0 +1,26 @@
+import SettingsService from '@js/Services/SettingsService';
+
+export default new class PasswordSettingsManager {
+
+    /**
+     *
+     */
+    constructor() {
+        this._showUsernameInList = null;
+    }
+
+    /**
+     *
+     */
+    async init() {
+        this._showUsernameInList = await SettingsService.get('password.list.show.user')
+    }
+
+    /**
+     *
+     */
+    getShowUserInList() {
+        return this._showUsernameInList.getValue();
+    }
+    
+}

--- a/src/js/Settings/MasterSettingsProvider.js
+++ b/src/js/Settings/MasterSettingsProvider.js
@@ -92,6 +92,10 @@ class MasterSettingsProvider {
             'clipboard.clear.delay' : [
                 'sync.clipboard.clear.delay',
                 'local.clipboard.clear.delay',
+            ],
+            'password.list.show.user' : [
+                'sync.password.list.show.user',
+                'local.password.list.show.user',
             ]
         };
         this._defaults = {
@@ -111,7 +115,8 @@ class MasterSettingsProvider {
             'search.recommendation.mode'   : 'host',
             'search.recommendation.maxRows': 8,
             'clipboard.clear.passwords'    : false,
-            'clipboard.clear.delay'        : 60
+            'clipboard.clear.delay'        : 60,
+            'password.list.show.user'      : false,
         };
     }
 

--- a/src/platform/generic/_locales/de/messages.json
+++ b/src/platform/generic/_locales/de/messages.json
@@ -1244,5 +1244,9 @@
     "InputSliderOff"    : {
         "message"     : "ausgeschaltet",
         "description" : "Tooltip of any slider input element that is currently in the inactive/disabled state"
+    },
+    "SettingsShowUsernameInList"  : {
+        "message"    : "Zeige Benutzername neben dem Titel",
+        "description": "Label of the setting in the extension settings to show the username next to the title in password lists."
     }
 }

--- a/src/platform/generic/_locales/en/messages.json
+++ b/src/platform/generic/_locales/en/messages.json
@@ -1258,5 +1258,9 @@
     "InputSliderOff"    : {
         "message"     : "Currently off",
         "description" : "Tooltip of any slider input element that is currently in the inactive/disabled state"
+    },
+    "SettingsShowUsernameInList"  : {
+        "message"    : "Show username next to title",
+        "description": "Label of the setting in the extension settings to show the username next to the title in password lists."
     }
 }

--- a/src/vue/Components/List/Item/Password.vue
+++ b/src/vue/Components/List/Item/Password.vue
@@ -2,7 +2,7 @@
     <li class="item password-item">
         <div class="label" @click="sendPassword()" :title="title">
             <favicon :password="password.getId()" :size="22" v-if="favicon"/>
-            {{ getLabel() }}
+            {{ label }}
         </div>
         <div class="options">
             <icon icon="user" hover-icon="clipboard" @click="copy('username', 'text')" draggable="true" @dragstart="drag($event, 'username')"/>
@@ -49,6 +49,13 @@
             },
             title() {
                 return LocalisationService.translate('PasswordItemTitle', this.password.getId(), this.password.getStatusCode());
+            },
+            label() {
+                var result = this.password.getLabel();
+                if(PasswordSettingsManager.getShowUserInList() && this.password.getUserName() !== "") {
+                    result = result + " - " + this.password.getUserName();
+                }
+                return result;
             }
         },
 
@@ -92,13 +99,6 @@
                 } catch(e) {
                     ErrorManager.logError(e);
                 }
-            },
-            getLabel() {
-                var result = this.password.getLabel();
-                if(PasswordSettingsManager.getShowUserInList() && this.password.getUserName() !== "") {
-                    result = result + " - " + this.password.getUserName();
-                }
-                return result;
             },
             copy(property, type) {
                 let data = this.password.getProperty(property);

--- a/src/vue/Components/List/Item/Password.vue
+++ b/src/vue/Components/List/Item/Password.vue
@@ -95,7 +95,7 @@
             },
             getLabel() {
                 var result = this.password.getLabel();
-                if(PasswordSettingsManager.getShowUserInList()) {
+                if(PasswordSettingsManager.getShowUserInList() && this.password.getUserName() !== "") {
                     result = result + " - " + this.password.getUserName();
                 }
                 return result;

--- a/src/vue/Components/List/Item/Password.vue
+++ b/src/vue/Components/List/Item/Password.vue
@@ -2,7 +2,7 @@
     <li class="item password-item">
         <div class="label" @click="sendPassword()" :title="title">
             <favicon :password="password.getId()" :size="22" v-if="favicon"/>
-            {{ password.getLabel() }}
+            {{ getLabel() }}
         </div>
         <div class="options">
             <icon icon="user" hover-icon="clipboard" @click="copy('username', 'text')" draggable="true" @dragstart="drag($event, 'username')"/>
@@ -21,6 +21,7 @@
     import ErrorManager from '@js/Manager/ErrorManager';
     import LocalisationService from '@js/Services/LocalisationService';
     import SettingsService from '@js/Services/SettingsService';
+    import PasswordSettingsManager from '@js/Manager/PasswordSettingsManager';
 
     export default {
         components: {Favicon, Icon},
@@ -91,6 +92,13 @@
                 } catch(e) {
                     ErrorManager.logError(e);
                 }
+            },
+            getLabel() {
+                var result = this.password.getLabel();
+                if(PasswordSettingsManager.getShowUserInList()) {
+                    result = result + " - " + this.password.getUserName();
+                }
+                return result;
             },
             copy(property, type) {
                 let data = this.password.getProperty(property);

--- a/src/vue/Components/Options/Settings.vue
+++ b/src/vue/Components/Options/Settings.vue
@@ -2,6 +2,10 @@
     <div class="settings-general">
         <translate tag="h3" say="AutofillSettings"/>
         <div class="setting">
+            <slider-field id="show-username-in-list" v-model="showUserInList"/>
+            <translate tag="label" for="show-username-in-list" say="SettingsShowUsernameInList"/>
+        </div>
+        <div class="setting">
             <slider-field id="paste-autoclose" v-model="autoclose"/>
             <translate tag="label" for="paste-autoclose" say="SettingsPastePopupClose"/>
         </div>
@@ -87,7 +91,8 @@
                 recSearchMode    : 'host',
                 recSearchRows    : 8,
                 clearClipboard   : false,
-                clearClipboardDelay: 60
+                clearClipboardDelay: 60,
+                showUserInList   : false,
             };
         },
 
@@ -227,6 +232,11 @@
             recSearchRows(value, oldValue) {
                 if(oldValue !== null && value !== oldValue) {
                     this.setSetting('search.recommendation.maxRows', value);
+                }
+            },
+            showUserInList(value, oldValue) {
+                if(oldValue !== null && value !== oldValue) {
+                    this.setSetting('password.list.show.user', value);
                 }
             }
         }

--- a/src/vue/Components/Options/Settings.vue
+++ b/src/vue/Components/Options/Settings.vue
@@ -153,6 +153,7 @@
                 this.getSetting('search.recommendation.maxRows', 'recSearchRows');
                 this.getSetting('clipboard.clear.passwords', 'clearClipboard');
                 this.getSetting('clipboard.clear.delay', 'clearClipboardDelay');
+                this.getSetting('password.list.show.user', 'showUserInList');
             },
             async getSetting(name, variable) {
                 try {


### PR DESCRIPTION
This introduces a new option to the password list in search and recommendation tabs. If the option is enabled, it shows the username of a page next to the title. This is useful if you have multiple accounts available for a login page and need to find the right user.

Fixes #88