### PR TITLE
fix console error for new clipboard feature

### DIFF
--- a/src/vue/Components/Options/Settings.vue
+++ b/src/vue/Components/Options/Settings.vue
@@ -24,7 +24,7 @@
             <help-text type="warning" text="HelpPasteBasicAuth"/>
         </div>
         <div class="setting">
-            <slider-field id="clipboard-clear-passwords" v-model="clearClipboard"/>
+            <slider-field id="clipboard-clear-passwords" v-model="clearClipboard" @change="requestClipboardReadPermission(clearClipboard)"/>
             <translate tag="label" for="clipboard-clear-passwords" say="SettingsClearClipboardPasswords"/>
             <help-text type="info" text="HelpClearClipboardPasswords"/>
         </div>
@@ -164,6 +164,9 @@
                     ErrorManager.logError(e);
                     ToastService.error(e.message).catch(ErrorManager.catch);
                 }
+            },
+            requestClipboardReadPermission(oldValue) {
+                if(oldValue !== true) ClipboardManager.requestReadPermission();
             }
         },
 
@@ -194,7 +197,6 @@
                 }
             },
             clearClipboard(value, oldValue) {
-                if(value === true) ClipboardManager.requestReadPermission();
                 if(oldValue !== null && value !== oldValue) {
                     this.setSetting('clipboard.clear.passwords', value);
                 }


### PR DESCRIPTION
I noticed that there is a console error on the background page when browsing to the advanced extension settings.
The error is caused by the new Clipborad Manager. If the clipboard clean feature is enabled while loading the page, it will request the permissions from the user. This causes issues because the event is not triggered by a human. It is triggered due to the initial settings load from the settings service.

For this reason, I moved the permission request to a dedicated method that fires only on change event of the user.