### PR TITLE
improve password recommendations and add domain mappings

### DIFF
--- a/src/js/Controller/Setting/Get.js
+++ b/src/js/Controller/Setting/Get.js
@@ -23,8 +23,8 @@ export default class Get extends AbstractController {
             'debug.localisation.enabled',
             'clipboard.clear.delay',
             'clipboard.clear.passwords',
-            'search.recommendation.mode',
-            'search.recommendation.maxRows'
+            'search.recommendation.maxRows',
+            'domain.mapping.list'
         ];
     }
 

--- a/src/js/Controller/Setting/Reset.js
+++ b/src/js/Controller/Setting/Reset.js
@@ -18,7 +18,6 @@ export default class Reset extends AbstractController {
             'theme.current',
             'theme.custom',
             'debug.localisation.enabled',
-            'search.recommendation.mode',
             'search.recommendation.maxRows',
             'clipboard.clear.passwords',
             'clipboard.clear.delay'

--- a/src/js/Controller/Setting/Set.js
+++ b/src/js/Controller/Setting/Set.js
@@ -37,8 +37,6 @@ export default class Set extends AbstractController {
                 await this._setDefaultServer(value);
             } else if(setting === 'theme.current') {
                 await this._setCurrentTheme(value);
-            } else if(setting === 'search.recommendation.mode') {
-                await this._setSearchRecommendationMode(value);
             } else if(setting === 'search.recommendation.maxRows') {
                 await this._setSearchRecommendationMaxRows(Number(value));
             } else if(setting === 'clipboard.clear.delay') {
@@ -86,16 +84,6 @@ export default class Set extends AbstractController {
     async _setCurrentTheme(value) {
         await ThemeRepository.findById(value);
         await SettingsService.set('theme.current', value);
-    }
-
-    /**
-     *
-     * @param {String} value
-     * @return {Promise<void>}
-     * @private
-     */
-    async _setSearchRecommendationMode(value) {
-        await SettingsService.set('search.recommendation.mode', value);
     }
 
     /**

--- a/src/js/Settings/MasterSettingsProvider.js
+++ b/src/js/Settings/MasterSettingsProvider.js
@@ -81,10 +81,6 @@ class MasterSettingsProvider {
                 'sync.search.recommendation.maxRows',
                 'local.search.recommendation.maxRows'
             ],
-            'search.recommendation.mode': [
-                'sync.search.recommendation.mode',
-                'local.search.recommendation.mode'
-            ],
             'clipboard.clear.passwords' : [
                 'sync.clipboard.clear.passwords',
                 'local.clipboard.clear.passwords',
@@ -92,6 +88,9 @@ class MasterSettingsProvider {
             'clipboard.clear.delay' : [
                 'sync.clipboard.clear.delay',
                 'local.clipboard.clear.delay',
+            ],
+            'domain.mapping.list' : [
+                'server.domain.mapping'
             ]
         };
         this._defaults = {
@@ -108,7 +107,6 @@ class MasterSettingsProvider {
             'notification.password.new'    : true,
             'notification.password.update' : true,
             'debug.localisation.enabled'   : true,
-            'search.recommendation.mode'   : 'host',
             'search.recommendation.maxRows': 8,
             'clipboard.clear.passwords'    : false,
             'clipboard.clear.delay'        : 60

--- a/src/platform/generic/_locales/de/messages.json
+++ b/src/platform/generic/_locales/de/messages.json
@@ -1202,10 +1202,6 @@
     "RecommendationSettings"     : {
         "message"    : "Passwort Empfehlung",
         "description": "Label of the section password recommendations in the extension settings."
-    },
-    "SettingsSearchRecommendationOption"     : {
-        "message"    : "Suche Passwort Empfehlung auf Basis von dieser Option.",
-        "description": "Label of the setting in the extension settings to define how password recommendations are searched."
     },    
     "LabelSearchRecommendationDomain"                 : {
         "message"    : "Domain",

--- a/src/platform/generic/_locales/en/messages.json
+++ b/src/platform/generic/_locales/en/messages.json
@@ -1216,11 +1216,7 @@
     "RecommendationSettings"     : {
         "message"    : "Password recommendations",
         "description": "Label of the section password recommendations in the extension settings."
-    },
-    "SettingsSearchRecommendationOption"     : {
-        "message"    : "Search passwords based on the following option.",
-        "description": "Label of the setting in the extension settings to define how password recommendations are searched."
-    },    
+    },  
     "LabelSearchRecommendationDomain"                 : {
         "message"    : "Domain",
         "description": "Find password recommendations by domain. So on page mail.example.com you will see all passwords for the domain and sumdomains of example.com."

--- a/src/vue/Components/Options/Settings.vue
+++ b/src/vue/Components/Options/Settings.vue
@@ -35,10 +35,6 @@
 
         <translate tag="h3" say="RecommendationSettings"/>
         <div class="setting">
-            <translate tag="label" for="search-recommendation-option" say="SettingsSearchRecommendationOption"/>
-            <select-field id="search-recommendation-option" :options="recommendationOptions" v-model="recSearchMode"/>
-        </div>
-        <div class="setting">
             <translate tag="label" for="search-recommendation-maxRows" say="SettingsSearchRecommendationMaxRows"/>
             <select-field id="search-recommendation-maxRows" :options="recommendationMaxRows" v-model="recSearchRows"/>
         </div>
@@ -84,7 +80,6 @@
                 notifyPwNew      : false,
                 relatedSearch    : false,
                 notifyPwUpdate   : false,
-                recSearchMode    : 'host',
                 recSearchRows    : 8,
                 clearClipboard   : false,
                 clearClipboardDelay: 60
@@ -144,7 +139,6 @@
                 this.getSetting('popup.related.search', 'relatedSearch');
                 this.getSetting('notification.password.new', 'notifyPwNew');
                 this.getSetting('notification.password.update', 'notifyPwUpdate');
-                this.getSetting('search.recommendation.mode', 'recSearchMode');
                 this.getSetting('search.recommendation.maxRows', 'recSearchRows');
                 this.getSetting('clipboard.clear.passwords', 'clearClipboard');
                 this.getSetting('clipboard.clear.delay', 'clearClipboardDelay');
@@ -217,11 +211,6 @@
             notifyPwUpdate(value, oldValue) {
                 if(oldValue !== null && value !== oldValue) {
                     this.setSetting('notification.password.update', value);
-                }
-            },
-            recSearchMode(value, oldValue) {
-                if(oldValue !== null && value !== oldValue) {
-                    this.setSetting('search.recommendation.mode', value);
                 }
             },
             recSearchRows(value, oldValue) {


### PR DESCRIPTION
This pull request makes further improvements in the password recommendations. I was not happy with my last implementation because not all users will get the best recommendations experience, and this is important for a good pasword management. So I decided to make further improvements by removing the extension setting for the search mode again.

The new search behavior for recommendations combines all previous search modes in an intelligent way. So the user will always get the best result based on the given page.

It will search on the following conditions and return all results. The results are ordered in the same way as they are queried here:

- Exact matches
- Host and port matches
- host matches
- domain and domain mapping matches

The new recommendations uses already the new api setting `server.domain.mapping` to consider also different domains which share the same credentials as described here: https://github.com/marius-wieschollek/passwords/pull/354
But of course the extension can also work without the new api setting to support also old installations.

The password mining was also modified. It will only ask for new passwords if the recommendations do not include a matching user password combination.