### PR TITLE
add scroll on hover function to password title

### DIFF
--- a/src/vue/Components/List/Item/Password.vue
+++ b/src/vue/Components/List/Item/Password.vue
@@ -146,10 +146,6 @@
         flex-shrink : 0;
     }
 
-    span.icon {
-        background-color : var(--element-bg-color);
-    }
-
     > .label {
         flex-grow     : 1;
         padding       : 0 .25rem 0 .5rem;
@@ -214,6 +210,7 @@
         display     : inline-block;
         line-height : 3rem;
         z-index     : 0;
+        background-color : inherit;
 
         &.secure {
             color : var(--success-bg-color)

--- a/src/vue/Components/List/Item/Password.vue
+++ b/src/vue/Components/List/Item/Password.vue
@@ -43,7 +43,7 @@
         },
 
         mounted(){ 
-            if(this.$refs.title.offsetWidth < this.$refs.title.scrollWidth) {
+            if(this.$refs.title.offsetWidth - 100 < this.$refs.title.scrollWidth) {
                 this.titleClass = "scroll-on-hover"
             } else {
                 this.titleClass = "";
@@ -146,6 +146,10 @@
         flex-shrink : 0;
     }
 
+    span.icon {
+        background-color : var(--element-bg-color);
+    }
+
     > .label {
         flex-grow     : 1;
         padding       : 0 .25rem 0 .5rem;
@@ -167,7 +171,7 @@
         }
 
         .scroll-on-hover:hover {
-            transform: translateX(calc(100vw - 6.5rem - 100%));
+            transform: translateX(calc(100vw - 9.5rem - 100%));
         }
         
         .favicon {

--- a/src/vue/Components/List/Item/Password.vue
+++ b/src/vue/Components/List/Item/Password.vue
@@ -2,7 +2,7 @@
     <li class="item password-item">
         <div class="label" @click="sendPassword()" :title="title">
             <favicon :password="password.getId()" :size="22" v-if="favicon"/>
-            {{ label }}
+            <span ref="title" :class="titleClass">{{ label }}</span>
         </div>
         <div class="options">
             <icon icon="user" hover-icon="clipboard" @click="copy('username', 'text')" draggable="true" @dragstart="drag($event, 'username')"/>
@@ -37,8 +37,17 @@
 
         data() {
             return {
-                active: true
+                active: true,
+                titleClass: ""
             };
+        },
+
+        mounted(){ 
+            if(this.$refs.title.offsetWidth < this.$refs.title.scrollWidth) {
+                this.titleClass = "scroll-on-hover"
+            } else {
+                this.titleClass = "";
+            }
         },
 
         computed: {
@@ -147,6 +156,20 @@
         text-overflow : ellipsis;
         transition    : min-width .25s ease-in-out;
 
+        span {
+            display: block;
+            width : inherit;
+        }
+        .scroll-on-hover {
+            position: absolute;
+            transform: translateX(0);
+            transition: 2s;
+        }
+
+        .scroll-on-hover:hover {
+            transform: translateX(calc(100vw - 6.5rem - 100%));
+        }
+        
         .favicon {
             vertical-align : middle;
             border-radius  : 3px;


### PR DESCRIPTION
This adds a scroll on hover function to the password title as requested here: 
https://github.com/marius-wieschollek/passwords-webextension/pull/159#issuecomment-796637937

The scrolling is only used if the password title is to long to display. E.g. if the title and username are used as title you might have to much text to display.

![scroll-on-hover](https://user-images.githubusercontent.com/52607335/110913983-15037780-8316-11eb-9872-1989dadd0cd2.gif)
