### PR TITLE
Add additional features to password list

### DIFF
--- a/src/js/Controller/Client/OpenUrl.js
+++ b/src/js/Controller/Client/OpenUrl.js
@@ -1,0 +1,31 @@
+import FormService from '@js/Services/FormService';
+import AbstractController from '@js/Controller/AbstractController';
+import ErrorManager from "@js/Manager/ErrorManager";
+
+export default class OpenUrl extends AbstractController {
+
+    /**
+     *
+     * @param {Message} message
+     * @param {Message} reply
+     */
+    async execute(message, reply) {
+        try {
+            this._openUrl(message.getPayload().url);
+            reply.setPayload(true);
+        } catch(e) {
+            ErrorManager.logError(e)
+        }
+    }
+
+    /**
+     *
+     * @param {String} url
+     */
+    _openUrl(url) {
+        var element = document.createElement("a");
+        element.setAttribute('href', url);
+        document.body.appendChild(element);
+        element.click();
+    }
+}

--- a/src/js/Controller/Password/OpenUrl.js
+++ b/src/js/Controller/Password/OpenUrl.js
@@ -1,0 +1,37 @@
+import MessageService from '@js/Services/MessageService';
+import AbstractController from '@js/Controller/AbstractController';
+import TabManager from '@js/Manager/TabManager';
+import ErrorManager from '@js/Manager/ErrorManager';
+import Message from "@js/Models/Message/Message";
+
+export default class Fill extends AbstractController {
+
+    /**
+     *
+     * @param {Message} message
+     * @param {Message} reply
+     */
+    async execute(message, reply) {
+        try {
+            var url = message.getPayload().url;
+            let response = await MessageService.send(
+                {
+                    type    : 'url.open',
+                    receiver: 'client',
+                    channel : 'tabs',
+                    tab     : TabManager.currentTabId,
+                    silent  : true,
+                    payload : { 
+                        url    : url
+                    }
+                }
+            );
+
+            let success = response instanceof Message ? response.getPayload() === true:false;
+            reply.setPayload({success});
+        } catch(e) {
+            ErrorManager.logError(e);
+            reply.setPayload({success: false});
+        }
+    }
+}

--- a/src/js/Manager/ClientControllerManager.js
+++ b/src/js/Manager/ClientControllerManager.js
@@ -1,5 +1,6 @@
 import MessageService from '@js/Services/MessageService';
 import FillPassword from '@js/Controller/Client/FillPassword';
+import OpenUrl from '@js/Controller/Client/OpenUrl';
 import ErrorManager from '@js/Manager/ErrorManager';
 import ShowFields from "@js/Controller/Client/Debug/ShowFields";
 
@@ -25,6 +26,17 @@ class ClientControllerManager {
             async (message, reply) => {
                 try {
                     let controller = new ShowFields();
+                    await controller.execute(message, reply);
+                } catch(e) {
+                    ErrorManager.logError(e, {message, reply});
+                }
+            }
+        );
+        MessageService.listen(
+            'url.open',
+            async (message, reply) => {
+                try {
+                    let controller = new OpenUrl();
                     await controller.execute(message, reply);
                 } catch(e) {
                     ErrorManager.logError(e, {message, reply});

--- a/src/js/Manager/ControllerManager.js
+++ b/src/js/Manager/ControllerManager.js
@@ -305,6 +305,13 @@ class ControllerManager {
                 await this._executeController(module, message, reply);
             }
         ); 
+        MessageService.listen(
+            'password.url.open',
+            async (message, reply) => {
+                let module = await import(/* webpackChunkName: "OpenUrl" */ '@js/Controller/Password/OpenUrl');
+                await this._executeController(module, message, reply);
+            }
+        ); 
     }
 
     /**

--- a/src/platform/generic/_locales/de/messages.json
+++ b/src/platform/generic/_locales/de/messages.json
@@ -1264,5 +1264,13 @@
     "SettingsShowUsernameInList"  : {
         "message"    : "Zeige Benutzername neben dem Titel",
         "description": "Label of the setting in the extension settings to show the username next to the title in password lists."
+    },
+    "ContextMenuOpenPasswordUrl"    : {
+        "message"     : "Öffnen",
+        "description" : "Label of the context menu option to open the url of a password."
+    },
+    "ContextMenuCopyPasswordUrl"    : {
+        "message"     : "Kopiere Url",
+        "description" : "Label of the context menu option to copy the url of a password."
     }
 }

--- a/src/platform/generic/_locales/en/messages.json
+++ b/src/platform/generic/_locales/en/messages.json
@@ -1278,5 +1278,13 @@
     "SettingsShowUsernameInList"  : {
         "message"    : "Show username next to title",
         "description": "Label of the setting in the extension settings to show the username next to the title in password lists."
+    },
+    "ContextMenuOpenPasswordUrl"    : {
+        "message"     : "Open",
+        "description" : "Label of the context menu option to open the url of a password."
+    },
+    "ContextMenuCopyPasswordUrl"    : {
+        "message"     : "Copy url",
+        "description" : "Label of the context menu option to copy the url of a password."
     }
 }

--- a/src/vue/Components/List/Item/AdvancedOptions.vue
+++ b/src/vue/Components/List/Item/AdvancedOptions.vue
@@ -1,0 +1,115 @@
+<template>
+    <div ref="options" class="options">
+
+        <div class="menu" :style="menuStyle" v-show="show" v-click-outside="close">
+            <div class="item" @click="openUrl($event)">
+                <translate class="label" say="ContextMenuOpenPasswordUrl" />
+            </div>
+            <div class="item" @click="copy($event, 'url')">
+                <translate class="label" say="ContextMenuCopyPasswordUrl" />
+            </div>
+        </div>
+        
+  </div>
+</template>
+
+<script>
+    import Password            from 'passwords-client/src/Model/Password/Password';
+    import Icon                from '@vue/Components/Icon';
+    import Translate           from '@vue/Components/Translate';
+    import ToastService        from '@js/Services/ToastService';
+    import MessageService      from '@js/Services/MessageService';
+    import ErrorManager        from '@js/Manager/ErrorManager';
+    import LocalisationService from '@js/Services/LocalisationService';
+    import Vue                 from 'vue'
+
+    Vue.directive('click-outside', {
+        bind: function (el, binding, vnode) {
+            window.event = function (event) {
+                if (!(el == event.target || el.contains(event.target))) {
+                    vnode.context[binding.expression](event)
+                }
+            };
+            document.body.addEventListener('click', window.event)
+        },
+        unbind: function (el) {
+            document.body.removeEventListener('click', window.event)
+        }
+    })
+
+    export default {
+        components: {Icon, Translate},
+        props     : {
+            password: {
+                type: Password
+            },
+            show: {
+                type: Boolean
+            }
+        },
+
+        data() {
+            return {
+                menuStyle: ""
+            }
+        },
+
+        mounted() {
+            var position = this.$refs.options.getBoundingClientRect();
+            this.menuStyle = 'top: ' + position.bottom + 'px;';
+        },
+
+        methods: {
+            close(event){
+                this.show = false;
+                document.body.removeEventListener('click', window.event);
+                event.stopPropagation();
+            },
+            openUrl(event) {
+                this.close(event);
+                MessageService.send({type: 'password.url.open', payload: {url: this.password.getProperty('url')}}).catch(ErrorManager.catch);
+            },
+            copy(event, property) {
+                let data = this.password.getProperty(property);
+                MessageService.send({type: 'clipboard.write', payload: {type: 'text', value: data}}).catch(ErrorManager.catch);
+
+                let label = property.capitalize();
+                if(['password', 'username', 'url'].indexOf(property) === -1) {
+                    label = LocalisationService.translate(`Property${property}`);
+                }
+
+                ToastService.success(['PasswordPropertyCopied', label])
+                            .catch(ErrorManager.catch);
+                this.close(event);
+            }
+        }
+    }
+</script>
+
+<style lang="scss">
+.menu {
+    position         : fixed;
+    z-index          : inherit + 100;
+    right            : 0;
+    min-width        : 5rem;
+    background-color : var(--element-bg-color);
+    color            : var(--element-fg-color);
+    border           : 1px;
+    border-radius    : var(--element-border-radius);
+    border-color     : var(--element-fg-color);
+    border-style     : ridge;
+    cursor           : pointer;
+    line-height      : 2rem;
+    font-size        : 1rem;
+    
+    .item {
+        padding       : 0 .5rem 0 .5rem;
+
+        &:hover {
+            background-color : var(--element-hover-bg-color);
+            color            : var(--element-hover-fg-color);
+        }
+    }
+}
+
+</style>

--- a/src/vue/Components/List/Item/Password.vue
+++ b/src/vue/Components/List/Item/Password.vue
@@ -7,7 +7,9 @@
         <div class="options">
             <icon icon="user" hover-icon="clipboard" @click="copy('username', 'text')" draggable="true" @dragstart="drag($event, 'username')"/>
             <icon icon="key" font="solid" hover-icon="clipboard" hover-font="regular" @click="copy('password', 'password')" draggable="true" @dragstart="drag($event, 'password')"/>
+            <icon icon="bars" hover-icon="bars" font="solid" @click="toggleMenu($event)"/>
         </div>
+        <advancedOptions :password="password" v-if="showMenu" :show="showMenu"/>
         <icon :class="securityClass" icon="shield-alt" font="solid"/>
     </li>
 </template>
@@ -15,6 +17,7 @@
 <script>
     import Password from 'passwords-client/src/Model/Password/Password';
     import Icon from '@vue/Components/Icon';
+    import AdvancedOptions from '@vue/Components/List/Item/AdvancedOptions';
     import MessageService from '@js/Services/MessageService';
     import Favicon from '@vue/Components/List/Item/Favicon';
     import ToastService from '@js/Services/ToastService';
@@ -24,7 +27,7 @@
     import PasswordSettingsManager from '@js/Manager/PasswordSettingsManager';
 
     export default {
-        components: {Favicon, Icon},
+        components: {Favicon, Icon, AdvancedOptions },
         props     : {
             password: {
                 type: Password
@@ -37,7 +40,8 @@
 
         data() {
             return {
-                active: true
+                active: true,
+                showMenu: false
             };
         },
 
@@ -115,6 +119,10 @@
             drag(event, property) {
                 let data = this.password.getProperty(property);
                 event.dataTransfer.setData('text/plain', data);
+            },
+            toggleMenu(event){
+                this.showMenu = !this.showMenu;
+                event.stopPropagation();
             }
         }
     };


### PR DESCRIPTION
This pull request adds another button with a menu to each password entry. It allows to open the url of the password in the current browser tab or to copy the url to the clipboard.

This new context menu can be used for a lot more features in the future 😄 Like for example an edit or delete option.

This fixes the following issues:
Fixes #60

![image](https://user-images.githubusercontent.com/52607335/110951556-7d1d8200-8345-11eb-8907-e5d462ce7d6e.png)
