### PR TITLE
fix password mining not working on some pages

### DIFF
--- a/src/js/Miner/DomMiner.js
+++ b/src/js/Miner/DomMiner.js
@@ -18,6 +18,14 @@ export default class DomMiner {
         );
 
         let forms = new FormService().getLoginFields();
+        if(forms.length > 0) {
+            this._addFormsListener(forms);
+        } else {
+            this._addBodyListener();
+        }        
+    }
+
+    _addFormsListener(forms) {
         for(let form of forms) {
             if(form.form) {
                 form.form.addEventListener(
@@ -35,6 +43,22 @@ export default class DomMiner {
                 );
             }
         }
+    }
+
+    _addBodyListener() {
+        const bodyObserver = new MutationObserver((mutations) => {
+            for (const mutation of mutations) {
+                if (mutation.type === "childList") {
+                    for (const added of mutation.addedNodes) {
+                        if (new FormService().getPasswordFields(added).length > 0) {
+                            bodyObserver.disconnect();
+                            this._addFormsListener(new FormService().getLoginFields());
+                        }
+                    }
+                }
+            }
+        });
+        bodyObserver.observe(document.body, { childList: true, subtree: true });
     }
 
     _checkForNewPassword() {

--- a/src/js/Services/FormService.js
+++ b/src/js/Services/FormService.js
@@ -1,7 +1,7 @@
 export default class FormService {
 
-    getPasswordFields() {
-        let fields         = document.querySelectorAll('input[type="password"]'),
+    getPasswordFields(rootNode = document) {
+        let fields         = rootNode.querySelectorAll('input[type="password"]'),
             excludes       = ['fake', 'hidden'],
             passwordFields = [];
 


### PR DESCRIPTION
This fixes a mining issue where password fields are detected correctly with the developer tools, but the mining manager is not aware of them. The reason is that the form service scans for password fields before all forms are loaded. For this reason I added another observer which will be enabled when no password form was detected. It will observe the dom elements for new password fields until it has found a valid one.

It fixes the following issue:
Fixes #138 