### PR TITLE
recommended passwords didn't always work

### DIFF
--- a/src/js/Manager/TabManager.js
+++ b/src/js/Manager/TabManager.js
@@ -29,6 +29,9 @@ class TabManager {
         this._tabUpdate = new EventQueue();
 
         this._updatedEvent = (tabId, changeInfo, tab) => {
+			if (changeInfo.sharingState) {
+				return;
+			}
             this._updateTabInfo(tab)
                 .catch(ErrorManager.catch());
         };


### PR DESCRIPTION
- sites like discord.com are sending every second a "tabs.onUpdated"
  event with the property "sharingState", and then
  TabManager._currentTab is overwritten and the password recommendations
  of discord loaded