### PR TITLE
fix search behavior during password edit

### DIFF
--- a/src/vue/App/Popup.vue
+++ b/src/vue/App/Popup.vue
@@ -88,8 +88,8 @@
                 PopupStateService.setTab($event.tab);
             },
             searchEvent($event) {
-                this.search.query = $event;
                 this.$refs.tabs.setActive('search');
+                setTimeout(() => document.getElementById('query').value += $event, 10);
             }
         }
     };

--- a/src/vue/Components/Popup/Related.vue
+++ b/src/vue/Components/Popup/Related.vue
@@ -52,7 +52,7 @@
                     });
             },
             search(event) {
-                if(event.target.tagName !== 'INPUT' && event.target.tagName !== 'TEXTAREA' && event.key.length === 1) {
+                if(document.getElementsByClassName("password-details-view").length == 0) {
                     this.$emit('search', event.key);
                 }
             }

--- a/src/vue/Components/Popup/Search.vue
+++ b/src/vue/Components/Popup/Search.vue
@@ -49,7 +49,9 @@
 
         methods: {
             focus() {
-               this.$refs.query.focus();
+                if(document.getElementsByClassName("password-details-view").length == 0) {
+                    this.$refs.query.focus();
+                }
             },
             search(query) {
                 MessageService


### PR DESCRIPTION
This PR fixes the following two issues:

1. During an edit/view of an existing password item, each keyboard command was send to the search field so that password edit was not working. You can reproduce the bug in the current version like this:
    - Open the Search tab
    - Search for an item and open the details view
    - Activate edit mode and type in the name field
    - You will be send to the search box and the current view is closed
2. On Password recommendations tab the search function was not more working. Pressing a key on the keyboard was not opening the search tab.