### PR TITLE
add keyboard shortcuts to open extension window window

### DIFF
--- a/src/platform/chrome/manifest.json
+++ b/src/platform/chrome/manifest.json
@@ -57,5 +57,12 @@
     ],
     "optional_permissions"   : [
         "clipboardRead"
-    ]
+    ],
+    "commands": {
+      "_execute_browser_action": {
+          "suggested_key": {
+              "default": "Alt+Shift+0"
+          }
+      }
+  }
 }

--- a/src/platform/fenix/manifest.json
+++ b/src/platform/fenix/manifest.json
@@ -85,5 +85,12 @@
     ],
     "optional_permissions"   : [
         "clipboardRead"
-    ]
+    ],
+    "commands": {
+      "_execute_browser_action": {
+        "suggested_key": {
+          "default": "Alt+Shift+0"
+        }
+      }
+    }
 }

--- a/src/platform/firefox/manifest.json
+++ b/src/platform/firefox/manifest.json
@@ -93,5 +93,12 @@
     ],
     "optional_permissions"   : [
         "clipboardRead"
-    ]
+    ],
+    "commands": {
+      "_execute_browser_action": {
+        "suggested_key": {
+          "default": "Alt+Shift+0"
+        }
+      }
+    }
 }


### PR DESCRIPTION
Hi, 

I've just implemented the changes you requested [here](https://github.com/marius-wieschollek/passwords-webextension/pull/206#discussion_r771815287) to add support for keyboard shortcuts for each platform.

I think these shortcuts will really help my and other peoples workflow 😄 

Please let me know if I need to change anything 